### PR TITLE
Fix: throw error if accordion element is not found

### DIFF
--- a/packages/accordion/src/accordion.ts
+++ b/packages/accordion/src/accordion.ts
@@ -12,13 +12,16 @@ export default class Accordion {
 
     constructor(accordion: string | HTMLElement, options: AccordionOptions = {}) {
         this.accordionEl = typeof accordion === "string" ? document.querySelector(accordion) as HTMLElement : accordion;
+        if (!this.accordionEl) {
+            throw new Error("Accordion element not found");
+        }
         this.options = {
             accordionType: this.accordionEl.dataset.accordionType as AccordionType || "single",
             preventClosingAll: this.accordionEl.hasAttribute("data-prevent-closing-all") || false,
             defaultValue: this.accordionEl.dataset.defaultValue || "",
             ...options,
         };
-        this.items = $$("[data-accordion-item]", this.accordionEl).filter((item) => item.parentElement === this.accordionEl);
+        this.items = $$("[data-accordion-item]", this.accordionEl).filter((item: { parentElement: HTMLElement; }) => item.parentElement === this.accordionEl);
         this.initAccordion();
     }
 


### PR DESCRIPTION
This pull request includes a critical update to the `Accordion` class in the `packages/accordion/src/accordion.ts` file. The most important changes are focused on improving error handling and type safety.

Error handling improvements:

* Added a check to ensure the `accordionEl` element exists and throws an error if it is not found.

Type safety enhancements:

* Updated the filter function for `this.items` to include type annotations, ensuring `item` is properly typed as an object with a `parentElement` property.