### PR TITLE
refactor(components): improve initialization and teleportation handling

### DIFF
--- a/packages/dropdown/src/dropdown.ts
+++ b/packages/dropdown/src/dropdown.ts
@@ -1,7 +1,7 @@
 import { DropdownOptions, ExperimentalOptions } from "./types"
 import { CreateOverlay, type Placement } from "flexipop/create-overlay"
 
-import { $$, $, keyboardNavigation, dispatchCustomEvent } from "@flexilla/utilities"
+import { $$, $, keyboardNavigation, dispatchCustomEvent, waitForFxComponents } from "@flexilla/utilities"
 import { FlexillaManager } from "@flexilla/manager"
 import { domTeleporter } from "@flexilla/utilities"
 
@@ -61,9 +61,6 @@ class Dropdown {
         restore: () => void;
     }
 
-
-
-
     /**
      * Creates a new Dropdown instance
      * @param dropdown - The dropdown content element or selector
@@ -87,6 +84,7 @@ class Dropdown {
         if (existingInstance) {
             return existingInstance;
         }
+        FlexillaManager.setup(this.contentElement)
         const triggerSelector = `[data-dropdown-trigger][data-dropdown-id=${this.contentElement.id}]`
         this.triggerElement = $(triggerSelector) as HTMLElement
         if (!(this.triggerElement instanceof HTMLElement)) {
@@ -146,6 +144,7 @@ class Dropdown {
 
 
         FlexillaManager.register('dropdown', this.contentElement, this)
+        FlexillaManager.initialized(this.contentElement)
     }
 
     private updateSubtriggerAttr = (trigger: HTMLElement, action: "add" | "remove") => {
@@ -157,7 +156,7 @@ class Dropdown {
             trigger.removeAttribute("data-focus")
         }
     }
-    private updateObserverFor =(observer:MutationObserver)=>{
+    private updateObserverFor = (observer: MutationObserver) => {
         const subtriggers = $$("[data-dropdown-trigger]", this.contentElement)
 
         for (const item of subtriggers) {
@@ -201,9 +200,11 @@ class Dropdown {
 
     private moveElOnInit = () => {
         if (this.experimentalOptions.teleport) {
-            if (this.experimentalOptions.teleportMode === "detachable")
-                this.teleporter.remove()
-            else this.teleporter.append()
+            waitForFxComponents(() => {
+                if (this.experimentalOptions.teleportMode === "detachable")
+                    this.teleporter.remove()
+                else this.teleporter.append()
+            })
         }
     }
 

--- a/packages/modal/src/modal.ts
+++ b/packages/modal/src/modal.ts
@@ -1,7 +1,7 @@
 
-import {  ModalContentAnimations, ModalOptions } from "./types";
+import { ModalContentAnimations, ModalOptions } from "./types";
 import { setBodyScrollable, toggleModalState } from "./helpers";
-import { $, $$, afterAnimation, dispatchCustomEvent } from "@flexilla/utilities";
+import { $, $$, afterAnimation, dispatchCustomEvent, waitForFxComponents } from "@flexilla/utilities";
 import { FlexillaManager } from "@flexilla/manager"
 import { buildOverlay, destroyOverlay } from "./modalOverlay";
 import { domTeleporter } from "@flexilla/utilities"
@@ -71,6 +71,7 @@ class Modal {
         if (!(modalContent instanceof HTMLElement)) {
             throw new Error("Modal content element not found or invalid. Please provide a valid HTMLElement or selector.")
         }
+        FlexillaManager.setup(this.modalElement)
         this.modalContent = modalContent
         const modalId = modalElement.dataset.modalId;
         this.modalId = `${modalId}`
@@ -97,10 +98,13 @@ class Modal {
 
         this.moveElOnInit()
         FlexillaManager.register('modal', this.modalElement, this)
+        FlexillaManager.initialized(this.modalElement)
     }
 
     private moveElOnInit = () => {
-        this.teleporter.append()
+        waitForFxComponents(() => {
+            this.teleporter.append()
+        })
     }
 
 

--- a/packages/modal/src/types.ts
+++ b/packages/modal/src/types.ts
@@ -6,12 +6,7 @@ export type ModalContentAnimations = {
     exitAnimation?: string;
 };
 
-export type ExperimentaOptions = {
-    /** Whether to teleport the dropdown content to the body or not
-     * @default false
-     */
-    teleport: boolean,
-}
+
 
 /**
  * Defines options for modal behavior.
@@ -27,6 +22,5 @@ export type ModalOptions = {
     beforeHide?:()=>{ cancelAction?: boolean;} |void;
     onShow?: () => void;
     onHide?: () => void;
-    onToggle?: ({ isHidden }: { isHidden: boolean }) => void,
-    experimental?: ExperimentaOptions,
+    onToggle?: ({ isHidden }: { isHidden: boolean }) => void
 };

--- a/packages/offcanvas/src/offcanvas.ts
+++ b/packages/offcanvas/src/offcanvas.ts
@@ -1,10 +1,9 @@
 
-import type {  OffcanvasOptions } from "./types"
+import type { OffcanvasOptions } from "./types"
 import { closeAllOpenedOffcanvas, toggleOffCanvasState } from "./helpers"
-import { appendBefore, $$, $, dispatchCustomEvent } from "@flexilla/utilities"
+import { appendBefore, $$, $, dispatchCustomEvent, domTeleporter, waitForFxComponents } from "@flexilla/utilities"
 import { createOverlay, destroyOverlay } from "./offCanvasOverlay"
 import { FlexillaManager } from "@flexilla/manager"
-import { domTeleporter } from "@flexilla/utilities"
 
 
 /**
@@ -65,6 +64,7 @@ class Offcanvas {
             return existingInstance;
         }
 
+        FlexillaManager.setup(this.offCanvasElement)
         this.options = options
         const { staticBackdrop, allowBodyScroll, backdrop: overlay } = this.options
 
@@ -86,10 +86,11 @@ class Offcanvas {
 
         this.moveElOnInit()
         FlexillaManager.register("offcanvas", this.offCanvasElement, this)
+        FlexillaManager.initialized(this.offCanvasElement)
     }
 
     private moveElOnInit = () => {
-        this.teleporter.append()
+        waitForFxComponents(() => this.teleporter.append())
     }
 
     private findOffCanvasElements(selector: string, hasChildren: boolean, offCanvasId: string | null, parent?: HTMLElement) {

--- a/packages/offcanvas/src/types.ts
+++ b/packages/offcanvas/src/types.ts
@@ -1,9 +1,3 @@
-export type ExperimentaOptions = {
-    /** Whether to teleport the dropdown content to the body or not
-     * @default false
-     */
-    teleport: boolean,
-}
 export type OffcanvasOptions = {
     staticBackdrop?: boolean,
     allowBodyScroll?: boolean,
@@ -11,6 +5,5 @@ export type OffcanvasOptions = {
     beforeHide?: () => { cancelAction?: boolean; } | void
     beforeShow?: () => void
     onShow?: () => void
-    onHide?: () => void,
-    experimental?: ExperimentaOptions,
+    onHide?: () => void
 }

--- a/packages/popover/src/popover.ts
+++ b/packages/popover/src/popover.ts
@@ -1,6 +1,6 @@
 import type { ExperimentaOptions, PopoverOptions } from "./types"
 import { CreateOverlay, type Placement } from 'flexipop/create-overlay'
-import { $, $$, dispatchCustomEvent } from "@flexilla/utilities"
+import { $, $$, dispatchCustomEvent, waitForFxComponents } from "@flexilla/utilities"
 import { FlexillaManager } from "@flexilla/manager"
 import { domTeleporter } from "@flexilla/utilities"
 
@@ -60,6 +60,7 @@ class Popover {
         if (existingInstance) {
             return existingInstance;
         }
+        FlexillaManager.setup(this.contentElement)
         this.triggerElement = $(`[data-popover-trigger][data-popover-id=${content.getAttribute("id")}]`) as HTMLElement
         this.options = options
         this.triggerStrategy = content.dataset.triggerStrategy as "click" | "hover" ?? (this.options.triggerStrategy ?? "click")
@@ -100,14 +101,17 @@ class Popover {
 
         this.moveElOnInit()
         FlexillaManager.register("popover", this.contentElement, this)
+        FlexillaManager.initialized(this.contentElement)
     }
 
 
     private moveElOnInit = () => {
         if (this.experimentalOptions.teleport) {
-            if (this.experimentalOptions.teleportMode === "detachable")
-                this.teleporter.remove()
-            else this.teleporter.append()
+            waitForFxComponents(() => {
+                if (this.experimentalOptions.teleportMode === "detachable")
+                    this.teleporter.remove()
+                else this.teleporter.append()
+            })
         }
     }
 

--- a/packages/tooltip/src/tooltip.ts
+++ b/packages/tooltip/src/tooltip.ts
@@ -1,5 +1,5 @@
 import { CreateOverlay, type Placement } from "flexipop/create-overlay"
-import { $, $$, dispatchCustomEvent } from "@flexilla/utilities"
+import { $, $$, dispatchCustomEvent, waitForFxComponents } from "@flexilla/utilities"
 import type { ExperimentaOptions, TooltipOptions } from "./types"
 import { FlexillaManager } from "@flexilla/manager"
 import { domTeleporter } from "@flexilla/utilities"
@@ -60,6 +60,7 @@ class Tooltip {
         if (existingInstance) {
             return existingInstance;
         }
+        FlexillaManager.setup(this.contentElement)
         this.triggerElement = $(`[data-tooltip-trigger][data-tooltip-id=${content.getAttribute("id")}]`) as HTMLElement
         this.options = options
         this.triggerStrategy = content.dataset.triggerStrategy as "click" | "hover" || this.options.triggerStrategy || "hover"
@@ -101,6 +102,7 @@ class Tooltip {
 
         this.moveElOnInit()
         FlexillaManager.register('tooltip', this.contentElement, this)
+        FlexillaManager.initialized(this.contentElement)
     }
 
 
@@ -108,9 +110,11 @@ class Tooltip {
 
     private moveElOnInit = () => {
         if (this.experimentalOptions.teleport) {
-            if (this.experimentalOptions.teleportMode === "detachable")
-                this.teleporter.remove()
-            else this.teleporter.append()
+            waitForFxComponents(() => {
+                if (this.experimentalOptions.teleportMode === "detachable")
+                    this.teleporter.remove()
+                else this.teleporter.append()
+            })
         }
     }
 


### PR DESCRIPTION
- Remove unused ExperimentaOptions type from modal and offcanvas
- Add FlexillaManager setup and initialized calls in component constructors
- Wrap teleporter operations in waitForFxComponents for consistent behavior